### PR TITLE
Feature/improve release process

### DIFF
--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -17,7 +17,6 @@ jobs:
   publish-python-gems:
     name: Publish to Python Package Index
     runs-on: ubuntu-18.04
-    needs: check-release
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -37,4 +37,5 @@ jobs:
         if: ${{ !inputs.test }}
         run: |
           cd ${{ needs.check-release.outputs.package }}
-          twine upload dist/* -u __token__ -p ${{ secrets.PYPI_API_KEY }}
+          echo PUBLISHING !!!
+          # twine upload dist/* -u __token__ -p ${{ secrets.PYPI_API_KEY }}

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:  
   publish-python-gems:
-    name: Publish to Python Package Index
+    name: Publish ${{ inputs.to_publish }} to PyPI
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -1,40 +1,21 @@
 name: (internal) - Publish
 
 on:
-  workflow_call:    
+  workflow_call:  
+    inputs:
+      test:
+        required: false
+        type: boolean
+      to_publish:
+        required: true
+        type: string
     secrets:
       PYPI_API_KEY:
         required: true
 
-jobs:
-  check-release:
-    name: Check Release
-    runs-on: ubuntu-18.04
-    outputs:
-      package: ${{ steps.step1.outputs.package }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
-      - name: Determining release type
-        id: step1
-        run: |
-          TAG=${{ github.ref }}
-          IFS='/' read -r -a array <<< "${TAG#refs/*/}"
-
-          if [ "${#array[@]}" -eq "2" ]; then
-              PACKAGE=${array[0]}
-              VERSION=${array[1]}
-
-              echo Is subpackage release. Publishing $PACKAGE v$VERSION to registry.
-              echo "package=$PACKAGE" >> $GITHUB_OUTPUT
-          else
-              echo Is main release. Skipping.
-          fi
-  
+jobs:  
   publish-python-gems:
     name: Publish to Python Package Index
-    if: needs.check-release.outputs.package != 0
     runs-on: ubuntu-18.04
     needs: check-release
     steps:
@@ -46,13 +27,14 @@ jobs:
         run: |
           pip3 install twine
           pip3 install wheel
-          pip3 install --requirement ${{ needs.check-release.outputs.package }}/requirements.txt
+          pip3 install --requirement ${{ inputs.to_publish }}/requirements.txt
         
       - name: "Build Package"
         run: |
-          cd ${{ needs.check-release.outputs.package }}
+          cd ${{ inputs.to_publish }}
           python3 setup.py sdist bdist_wheel
       - name: "Publish Package"
+        if: ${{ !inputs.test }}
         run: |
           cd ${{ needs.check-release.outputs.package }}
           twine upload dist/* -u __token__ -p ${{ secrets.PYPI_API_KEY }}

--- a/.github/workflows/_publish_all.yml
+++ b/.github/workflows/_publish_all.yml
@@ -1,0 +1,75 @@
+name: (internal) - Publish All
+
+on:
+  workflow_call:
+    inputs:
+      test:
+        required: false
+        type: boolean
+    secrets:
+      PYPI_API_KEY:
+        required: true
+
+jobs:
+  publish-audit-api:
+    name: Publish Audit API
+    uses: ./.github/workflows/_publish.yml
+    secrets:
+      PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}
+    with:
+      test: ${{ inputs.test }}
+      to_publish: pnap_audit_api
+
+  publish-bmc-api:
+    name: Publish BMC API
+    uses: ./.github/workflows/_publish.yml
+    secrets:
+      PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}
+    with:
+      test: ${{ inputs.test }}
+      to_publish: pnap_bmc_api
+
+  publish-ip-api:
+    name: Publish IP API
+    uses: ./.github/workflows/_publish.yml
+    secrets:
+      PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}
+    with:
+      test: ${{ inputs.test }}
+      to_publish: pnap_ip_api
+
+  publish-network-api:
+    name: Publish Network API
+    uses: ./.github/workflows/_publish.yml
+    secrets:
+      PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}
+    with:
+      test: ${{ inputs.test }}
+      to_publish: pnap_network_api
+
+  publish-network-storage-api:
+    name: Publish Network Storage API
+    uses: ./.github/workflows/_publish.yml
+    secrets:
+      PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}
+    with:
+      test: ${{ inputs.test }}
+      to_publish: pnap_network_storage_api
+
+  publish-rancher-solution-api:
+    name: Publish Rancher Solution API
+    uses: ./.github/workflows/_publish.yml
+    secrets:
+      PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}
+    with:
+      test: ${{ inputs.test }}
+      to_publish: pnap_rancher_solution_api
+
+  publish-tag-api:
+    name: Publish Tag API
+    uses: ./.github/workflows/_publish.yml
+    secrets:
+      PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}
+    with:
+      test: ${{ inputs.test }}
+      to_publish: pnap_tag_api

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -2,6 +2,7 @@ name: publish-sdk-test
 
 on:
   workflow_dispatch:
+  push:
 
 jobs:
   build-and-test-bmcapi:

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -2,7 +2,6 @@ name: publish-sdk-test
 
 on:
   workflow_dispatch:
-  push:
 
 jobs:
   build-and-test-bmcapi:
@@ -50,7 +49,7 @@ jobs:
       - build-and-test-ipapi
       - build-and-test-auditapi
       - build-and-test-tagapi
-      # - build-and-test-networkstorageapi
+      - build-and-test-networkstorageapi
     uses: ./.github/workflows/_publish_all.yml
     secrets: 
       PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,4 +1,4 @@
-name: publish-sdk
+name: publish-sdk-test
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,8 +1,7 @@
 name: publish-sdk
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
   build-and-test-bmcapi:
@@ -51,8 +50,8 @@ jobs:
       - build-and-test-auditapi
       - build-and-test-tagapi
       - build-and-test-networkstorageapi
-    uses: ./.github/workflows/_publish.yml
+    uses: ./.github/workflows/_publish_all.yml
     secrets: 
       PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}
     with:
-      test: false
+      test: true

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -50,7 +50,7 @@ jobs:
       - build-and-test-ipapi
       - build-and-test-auditapi
       - build-and-test-tagapi
-      - build-and-test-networkstorageapi
+      # - build-and-test-networkstorageapi
     uses: ./.github/workflows/_publish_all.yml
     secrets: 
       PYPI_API_KEY: ${{ secrets.PYPI_API_KEY }}


### PR DESCRIPTION
Improves the release process via two steps
1. Adds an option to test the release, by a workflow that can be manually triggered. This workflow is functionally identical to the normal release process, except it stops just before publishing to the registry - allowing a release to be simulated before it's actually performed on the `master` branch.
2. Updates the release process so that _all_ sub-SDKs are published at once, rather than requiring a release for every sub-SDK. This simplifies the logic since there's no need to parse the tag, and makes it easier to release, requiring 1 instead of 7+ github releases.